### PR TITLE
Make ODP endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,28 @@
 ## Setup
 ### ODP
 Before we can see the odp fields for the customer table and lists for campaigns, we need to enter the private api key into the configuration manager for handling the connection between the ODP connector and ODP REST API.
+
 To do so, we must first login to ODP and navigate to the account settings page.  Once we have hit the account settings page, we care going to click on "APIs" under the DATA MANAGEMENT section.  This will bring us to the APIs page which will allow us to copy the private key from the tab pane.
+
 Copy the key somewhere safe.
+
 ![ODP Account Settings](https://github.com/optimizely/marketingautomationintegration-odp/blob/main/images/ODP-AccountSettings.png)
 ### Optimizely
-Once we have our api key, we are going to head over the the web.config and you should see 2 entries.  You will need to update the appSettings key *"ma-odp-apikey"*.  Once the key is inserted into the config value, you should be done with configuration
+#### CMS 11
+Once we have our api key, we are going to head over the the web.config and you should see 3 entries.  You will need to update the appSettings key *"ma-odp-apikey"*.  Once the key is inserted into the config value, you should be done with configuration
 ```xml
-<add key="ma-odp-apikey" value="" />
+<add key="ma-odp-odpbaseendpoint" value="https://api.zaius.com/" />
+<add key="ma-odp-customerobjectname" value="customers" />
+<add key="ma-odp-apikey" value="changeme" />
+```
+#### CMS 12
+Once we have our api key, we are going to head over the the appsettings.json file and configure the add-on.  You will need to update the APIKey in the snippet below, and then add the configuration to appsettings.json.
+```json
+  ...
+  },
+  "MAIOdpSettings": {
+	"OdpBaseEndPoint": "https://api.zaius.com/",
+    "CustomerObjectName": "customers",
+    "APIKey": "changeme"
+  }
 ```

--- a/dotnet/Optimizely.Labs.MarketingAutomationIntegration.ODP/MAIOdpSettings.cs
+++ b/dotnet/Optimizely.Labs.MarketingAutomationIntegration.ODP/MAIOdpSettings.cs
@@ -2,8 +2,8 @@
 {
     public class MAIOdpSettings
     {
+        public string OdpBaseEndPoint { get; set; }
         public string CustomerObjectName { get; set; }
-
         public string APIKey { get; set; }
     }
 }

--- a/dotnet/Optimizely.Labs.MarketingAutomationIntegration.ODP/Services/IODPService.cs
+++ b/dotnet/Optimizely.Labs.MarketingAutomationIntegration.ODP/Services/IODPService.cs
@@ -26,8 +26,6 @@ namespace Optimizely.Labs.MarketingAutomationIntegration.ODP.Services
 
     public class ODPService : IODPService
     {
-        private const string BaseUrl = "https://api.zaius.com/";
-
         private readonly HttpClient client = new HttpClient();
 
         private readonly ISynchronizedObjectInstanceCache _objectInstanceCache;
@@ -35,10 +33,15 @@ namespace Optimizely.Labs.MarketingAutomationIntegration.ODP.Services
 
         public ODPService(ISynchronizedObjectInstanceCache objectInstanceCache, IOptions<MAIOdpSettings> config)
         {
+            string BaseUrl = "https://api.zaius.com/";
             _objectInstanceCache = objectInstanceCache;
             _config = config?.Value ?? throw new Exception("MAIOdpSettings is not configured in appSettings.json");
-            if(string.IsNullOrEmpty(_config.CustomerObjectName) || string.IsNullOrEmpty(_config.APIKey))
-                throw new Exception("MAIOdpSettings:CustomerObjectName or  MAIOdpSettings:APIKey is not configured in appSettings.json");
+            if (!string.IsNullOrEmpty(_config.OdpBaseEndPoint))
+            {
+                BaseUrl = _config.OdpBaseEndPoint;
+            }
+            if (string.IsNullOrEmpty(_config.CustomerObjectName) || string.IsNullOrEmpty(_config.APIKey))
+                throw new Exception("MAIOdpSettings:CustomerObjectName or MAIOdpSettings:APIKey is not configured in appSettings.json");
             this.client = new HttpClient()
             {
                 BaseAddress = new System.Uri(BaseUrl)

--- a/dotnet/web.config.transform
+++ b/dotnet/web.config.transform
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
+		<add key="ma-odp-odpbaseendpoint" value="https://api.zaius.com/" />
 		<add key="ma-odp-customerobjectname" value="customers" />
 		<add key="ma-odp-apikey" value="" />
     </appSettings>

--- a/legacy/Optimizely.Labs.MarketingAutomationIntegration.ODP/Services/IODPService.cs
+++ b/legacy/Optimizely.Labs.MarketingAutomationIntegration.ODP/Services/IODPService.cs
@@ -1,4 +1,5 @@
-﻿using EPiServer.Framework.Cache;
+﻿using Castle.Core.Internal;
+using EPiServer.Framework.Cache;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -25,14 +26,14 @@ namespace Optimizely.Labs.MarketingAutomationIntegration.ODP.Services
 
     public class ODPService : IODPService
     {
-        private const string BaseUrl = "https://api.zaius.com/";
-
         private readonly HttpClient client = new HttpClient();
 
         private readonly ISynchronizedObjectInstanceCache _objectInstanceCache;
 
         public ODPService(ISynchronizedObjectInstanceCache objectInstanceCache)
         {
+            string BaseUrl = (SettingsOptions.OdpBaseEndPoint).IsNullOrEmpty() ? "https://api.zaius.com/" : SettingsOptions.OdpBaseEndPoint;
+
             _objectInstanceCache = objectInstanceCache;
             this.client = new HttpClient()
             {

--- a/legacy/Optimizely.Labs.MarketingAutomationIntegration.ODP/SettingsOptions.cs
+++ b/legacy/Optimizely.Labs.MarketingAutomationIntegration.ODP/SettingsOptions.cs
@@ -6,9 +6,12 @@ namespace Optimizely.Labs.MarketingAutomationIntegration.ODP
     {
         static SettingsOptions()
         {
+            OdpBaseEndPoint = ConfigurationManager.AppSettings["ma-odp-odpbaseendpoint"];
             CustomerObjectName = ConfigurationManager.AppSettings["ma-odp-customerobjectname"];
             APIKey = ConfigurationManager.AppSettings["ma-odp-apikey"];
         }
+
+        public static string OdpBaseEndPoint { get; }
 
         public static string CustomerObjectName { get; }
 

--- a/legacy/web.config.transform
+++ b/legacy/web.config.transform
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
+		<add key="ma-odp-odpbaseendpoint" value="https://api.zaius.com/" />
 		<add key="ma-odp-customerobjectname" value="customers" />
 		<add key="ma-odp-apikey" value="" />
     </appSettings>


### PR DESCRIPTION
Set the ODP endpoint in the configuration, for non-US ODP users.

Default/fallback endpoint still set to https://api.zaius.com/